### PR TITLE
Fix problem in re login

### DIFF
--- a/src/utils/State.js
+++ b/src/utils/State.js
@@ -5,10 +5,12 @@ export const State = React.createContext();
 export const StateProvider = (props) => {
 
   const set = (key, value) => {
-    const newState = {...state, [key]: value};
-    const localStorageState = JSON.parse(localStorage.getItem('state')) || {};
-    localStorage.setItem('state', JSON.stringify(Object.assign(localStorageState, newState)));
-    return setState(newState);
+    return setState(oldState => {
+      const newState = {...oldState, [key]: value};
+      const localStorageState = JSON.parse(localStorage.getItem('state')) || {};
+      localStorage.setItem('state', JSON.stringify(Object.assign(localStorageState, newState)));  
+      return newState;
+    });
   };
 
   const initState = {


### PR DESCRIPTION
Now if you have an expired token and you try to re login, first call to `GET /auth/profile` is working, but the `GET /courses` is failing because it is using the old token. 

![relogin-bug](https://user-images.githubusercontent.com/13502684/72301737-837f7380-3646-11ea-9d63-29f5441c94b2.gif)

The problem was in the following line:
https://github.com/tutecano1995/RPL-2.0-web/blob/6bf92a42800e17db801fee46b849254340acdf4f/src/utils/State.js#L8

`state` was not updated, so we were always using the same _base_ state.
