### PR TITLE
Fixes consecutive newlines view in IO test results

### DIFF
--- a/src/components/SubmissionResultModal/TestResultsModal.react.js
+++ b/src/components/SubmissionResultModal/TestResultsModal.react.js
@@ -273,6 +273,7 @@ class SubmissionResultModal extends React.Component<Props, State> {
                   const separateNewLines = str => (
                     str.replace(/(\n)\1+/g, str => str.split('').join(' '))
                   );
+                  // Hack to fix issue #97 where '\n\n' is not displayed in diff viewer correctly but '\n \n' does
                   ioResult.run_output = separateNewLines(ioResult.run_output);
                   ioResult.expected_output = separateNewLines(ioResult.expected_output);
                   return (

--- a/src/components/SubmissionResultModal/TestResultsModal.react.js
+++ b/src/components/SubmissionResultModal/TestResultsModal.react.js
@@ -270,6 +270,11 @@ class SubmissionResultModal extends React.Component<Props, State> {
                           },
                         }
                       : {};
+                  const separateNewLines = str => (
+                    str.replace(/(\n)\1+/g, str => str.split('').join(' '))
+                  );
+                  ioResult.run_output = separateNewLines(ioResult.run_output);
+                  ioResult.expected_output = separateNewLines(ioResult.expected_output);
                   return (
                     <DialogContentText
                       key={idx}


### PR DESCRIPTION
Arregla #97 agregando en los resultados un espacio entre cada par de salto de línea consecutivo.

![image](https://user-images.githubusercontent.com/4763786/113480016-90b19980-9468-11eb-8eb1-4d390e8ff76b.png)


Esta sería la solución barata sin meterse a modificar el `ReactDiffViewer`, porque no se le puede pasar un `compareMethod` diferente a las siete opciones que provee, y ninguna de esas resuelve el problema.