### PR TITLE
Revert "Bump react-sliding-side-panel from 1.1.8 to 2.0.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "react-resize-detector": "^4.2.1",
         "react-router-dom": "^5.2.0",
         "react-showdown": "^2.3.0",
-        "react-sliding-side-panel": "^2.0.3",
+        "react-sliding-side-panel": "^1.1.8",
         "react-split-pane": "^0.1.92",
         "showdown": "^1.9.1",
         "webpack-dotenv-plugin": "^2.1.0"
@@ -3212,6 +3212,28 @@
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "16.9.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.10.tgz",
+      "integrity": "sha512-ItatOrnXDMAYpv6G8UCk2VhbYVTjZT9aorLtA/OzDN9XJ2GKcfam68jutoAcILdRjsRUO8qb7AmyObF77Q8QFw==",
+      "dependencies": {
+        "@types/react": "^16"
+      }
+    },
+    "node_modules/@types/react-dom/node_modules/@types/react": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
+      "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom/node_modules/csstype": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
     },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.0",
@@ -12100,48 +12122,32 @@
       }
     },
     "node_modules/react-sliding-side-panel": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/react-sliding-side-panel/-/react-sliding-side-panel-2.0.3.tgz",
-      "integrity": "sha512-5uujAqwu9XhTPmlvP58TDjHMusFTg3/AE4ROxU8GG+cEUHNq4s43mAiLOZa1gHu39jCLMlSgzHT7fsKQrTutYg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/react-sliding-side-panel/-/react-sliding-side-panel-1.1.8.tgz",
+      "integrity": "sha512-G11bdjK3lyddKV8PINhrwVPTfkq9O15dMgM1bvIqwNCN2MOfiEvrjIdL7aR8SbAO7eFHIsPGNr1J4JToMLiFyw==",
       "dependencies": {
-        "react": "^17.0.1",
-        "react-dom": "^17.0.1",
-        "react-transition-group": "^4.4.1"
+        "@types/react": "^16.9.46",
+        "@types/react-dom": "^16.9.8",
+        "@types/react-transition-group": "^4.4.0",
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1",
+        "react-transition-group": "^4.4.1",
+        "typescript": "^3.9.7"
       }
     },
-    "node_modules/react-sliding-side-panel/node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+    "node_modules/react-sliding-side-panel/node_modules/@types/react": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
+      "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
       }
     },
-    "node_modules/react-sliding-side-panel/node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      },
-      "peerDependencies": {
-        "react": "17.0.2"
-      }
-    },
-    "node_modules/react-sliding-side-panel/node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
+    "node_modules/react-sliding-side-panel/node_modules/csstype": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
     },
     "node_modules/react-split-pane": {
       "version": "0.1.92",
@@ -14272,6 +14278,18 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
     "node_modules/uglify-js": {
       "version": "3.4.10",
@@ -18490,6 +18508,30 @@
           "version": "3.0.8",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
           "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+        }
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.9.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.10.tgz",
+      "integrity": "sha512-ItatOrnXDMAYpv6G8UCk2VhbYVTjZT9aorLtA/OzDN9XJ2GKcfam68jutoAcILdRjsRUO8qb7AmyObF77Q8QFw==",
+      "requires": {
+        "@types/react": "^16"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "16.14.2",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
+          "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
+          "requires": {
+            "@types/prop-types": "*",
+            "csstype": "^3.0.2"
+          }
+        },
+        "csstype": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
         }
       }
     },
@@ -26077,42 +26119,32 @@
       }
     },
     "react-sliding-side-panel": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/react-sliding-side-panel/-/react-sliding-side-panel-2.0.3.tgz",
-      "integrity": "sha512-5uujAqwu9XhTPmlvP58TDjHMusFTg3/AE4ROxU8GG+cEUHNq4s43mAiLOZa1gHu39jCLMlSgzHT7fsKQrTutYg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/react-sliding-side-panel/-/react-sliding-side-panel-1.1.8.tgz",
+      "integrity": "sha512-G11bdjK3lyddKV8PINhrwVPTfkq9O15dMgM1bvIqwNCN2MOfiEvrjIdL7aR8SbAO7eFHIsPGNr1J4JToMLiFyw==",
       "requires": {
-        "react": "^17.0.1",
-        "react-dom": "^17.0.1",
-        "react-transition-group": "^4.4.1"
+        "@types/react": "^16.9.46",
+        "@types/react-dom": "^16.9.8",
+        "@types/react-transition-group": "^4.4.0",
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1",
+        "react-transition-group": "^4.4.1",
+        "typescript": "^3.9.7"
       },
       "dependencies": {
-        "react": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+        "@types/react": {
+          "version": "16.14.2",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
+          "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
           "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
+            "@types/prop-types": "*",
+            "csstype": "^3.0.2"
           }
         },
-        "react-dom": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-          "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "scheduler": "^0.20.2"
-          }
-        },
-        "scheduler": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
+        "csstype": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
         }
       }
     },
@@ -27959,6 +27991,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typescript": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "react-resize-detector": "^4.2.1",
     "react-router-dom": "^5.2.0",
     "react-showdown": "^2.3.0",
-    "react-sliding-side-panel": "^2.0.3",
+    "react-sliding-side-panel": "^1.1.8",
     "react-split-pane": "^0.1.92",
     "showdown": "^1.9.1",
     "webpack-dotenv-plugin": "^2.1.0"


### PR DESCRIPTION
Reverts reinvent-fiuba/RPL-2.0-web#113 since it was causing some issues

![yFbGMx5ON2](https://user-images.githubusercontent.com/13502684/115797102-7bfe5c80-a3a9-11eb-98d8-7dc902007215.gif)
