### PR TITLE
Replace activity title by breadcrumb

### DIFF
--- a/src/components/FinalActivitiesPage/FinalActivitiesPage.js
+++ b/src/components/FinalActivitiesPage/FinalActivitiesPage.js
@@ -241,7 +241,7 @@ class FinalActivitiesPage extends React.Component<Props, State> {
         {activity && (
           <main className={classes.content}>
             <div className={classes.drawerHeader} />
-            <SolvePageHeader activityName={activity.name} onlyTitle />
+            <SolvePageHeader activity={activity} history={history} onlyTitle />
             <SolveActivityFirstModal
               open={openModal}
               teacherMode={teacherMode}

--- a/src/components/SolveActivityPage/SolveActivityPage.js
+++ b/src/components/SolveActivityPage/SolveActivityPage.js
@@ -248,7 +248,7 @@ class SolveActivityPage extends React.Component<Props, State> {
             <SolvePageHeader
               handleSubmitActivity={e => this.handleSubmitActivity(e)}
               handleOpenPastSubmissionsSidePanel={() => this.setOpenSubmissionsPanel()}
-              activityName={activity.name}
+              activity={activity}
               history={history}
               canShowOtherSolutions={finalSolutionId !== null}
             />

--- a/src/components/SolveActivityPage/SolvePageHeader.react.js
+++ b/src/components/SolveActivityPage/SolvePageHeader.react.js
@@ -5,6 +5,11 @@ import Button from "@material-ui/core/Button";
 import { withStyles } from "@material-ui/core/styles";
 import { withState } from "../../utils/State";
 
+import Breadcrumbs from "@material-ui/core/Breadcrumbs";
+import Link from "@material-ui/core/Link";
+import { Link as RouterLink } from "react-router-dom";
+const LinkRouter = props => <Link {...props} component={RouterLink} />;
+
 const styles = theme => ({
   secondHeader: {
     backgroundColor: theme.palette.background.default,
@@ -26,7 +31,7 @@ const styles = theme => ({
   topRightButtons: {
     alignSelf: "flex-end",
   },
-  mySubmissionsButton: {
+  rightButton: {
     marginRight: "5px",
   },
 });
@@ -34,7 +39,7 @@ const styles = theme => ({
 type Props = {
   handleSubmitActivity: Event => void,
   handleOpenPastSubmissionsSidePanel: void => void,
-  activityName: string,
+  activity: string,
   classes: any,
   style: any,
   history: any,
@@ -50,7 +55,10 @@ function getLeftTitle(
 ) {
   if (permissions.includes("activity_manage")) {
     return (
-      <Button onClick={() => history.push(`${history.location.pathname}/edit`)}>
+      <Button
+        className={classes.rightButton}
+        onClick={() => history.push(`${history.location.pathname}/edit`)}
+      >
         Volver a modo profesor
       </Button>
     );
@@ -59,8 +67,7 @@ function getLeftTitle(
     <Button
       type="submit"
       variant="contained"
-      color="primary"
-      className={classes.topRightButtons}
+      className={classes.rightButton}
       disabled={!canShowOtherSolutions}
       onClick={() => history.push(`${history.location.pathname}/definitives`)}
     >
@@ -70,21 +77,29 @@ function getLeftTitle(
 }
 
 function SolvePageHeader(props: Props) {
+  const { course } = props.context;
+  const { activity } = props;
   return (
     <div style={props.style} className={props.classes.secondHeader}>
+      <Breadcrumbs aria-label="breadcrumb">
+        <LinkRouter color="inherit" to={`/courses/${course.id}/dashboard`}>
+          {props.context.course.name}
+        </LinkRouter>
+        <LinkRouter color="inherit" to={`/courses/${course.id}/activities`}>
+          Actividades
+        </LinkRouter>
+        <LinkRouter color="inherit" to={props.history.location.pathname}>
+          {activity.name}
+        </LinkRouter>
+      </Breadcrumbs>
       {!props.onlyTitle && (
-        <div className={props.classes.topLeftButtons}>
+        <div className={props.classes.topRightButtons}>
           {getLeftTitle(
             props.history,
             props.context.permissions,
             props.classes,
             props.canShowOtherSolutions
           )}
-        </div>
-      )}
-      <h2 className={props.classes.secondHeaderTitle}>{props.activityName}</h2>
-      {!props.onlyTitle && (
-        <div className={props.classes.topRightButtons}>
           <Button
             type="submit"
             variant="contained"

--- a/src/components/SolveActivityPage/SolvePageHeader.react.js
+++ b/src/components/SolveActivityPage/SolvePageHeader.react.js
@@ -104,7 +104,7 @@ function SolvePageHeader(props: Props) {
             type="submit"
             variant="contained"
             color="primary"
-            className={props.classes.mySubmissionsButton}
+            className={props.classes.rightButton}
             onClick={e => props.handleOpenPastSubmissionsSidePanel()}
           >
             Mis entregas


### PR DESCRIPTION
## Solution

- With these changes, it's possible to go back from a specific activity page to the list of all activities through the breadcrumb.  
    _Con estos cambios, es posible ir atrás desde la pagina de una actividad específica a la  todas las actividades usando el breadcrumb._

### Before
<img height="50%" width="70%" src="https://user-images.githubusercontent.com/13502684/119900996-b06eb680-bf1b-11eb-9681-fadf91206200.png" />

### After
<img height="50%" width="70%" src="https://user-images.githubusercontent.com/13502684/119900875-7d2c2780-bf1b-11eb-9dc1-9345425e18eb.png" />
