### PR TITLE
Feature/Change current activity in solve activity page

### DIFF
--- a/src/PrivateRoute.js
+++ b/src/PrivateRoute.js
@@ -23,7 +23,7 @@ function PrivateRoute({ component: Component, layout: Layout, title, context, ..
           );
         }
         return (
-          <Layout title={title}>
+          <Layout title={title} key={location.pathname}>
             <Component {...routeProps} />
           </Layout>
         );

--- a/src/components/SolveActivityPage/SolveActivityPage.js
+++ b/src/components/SolveActivityPage/SolveActivityPage.js
@@ -52,8 +52,6 @@ type State = {
   editor: any,
   pastSubmissionsPanel: { isOpen: boolean, selectedSubmissionId: ?number },
   finalSolutionId: ?number,
-  activityMenu: { isOpen: boolean, anchorEl: ?string },
-  activityOptions: { options: Array<any> }
 };
 
 class SolveActivityPage extends React.Component<Props, State> {
@@ -67,8 +65,6 @@ class SolveActivityPage extends React.Component<Props, State> {
     editor: null,
     pastSubmissionsPanel: { isOpen: false, selectedSubmissionId: null },
     finalSolutionId: null,
-    activityMenu: { isOpen: false, anchorEl: null },
-    activityOptions: []
   };
 
   componentDidMount() {
@@ -90,22 +86,6 @@ class SolveActivityPage extends React.Component<Props, State> {
             }
             return Promise.reject(err);
           });
-        activitiesService
-          .getAllActivities(this.props.match.params.courseId)
-          .then(activitiesResponse => {
-            let activities = activitiesResponse
-              .filter(activity => (activity.category_id === activityResponse.category_id && activity.active))
-              .sort((a, b) => a.name > b.name);
-            this.setState({
-              activityOptions: activities.map(activity => ({id: activity.id, name: activity.name}))
-            })
-            .catch(err => {
-              if (err.status === 404) {
-                return Promise.resolve(this.setState({ activityOptions: [] }));
-              }
-              return Promise.reject(err);
-            });
-          })
       })
       .catch(err => {
         console.log(err);
@@ -175,14 +155,6 @@ class SolveActivityPage extends React.Component<Props, State> {
     this.setState({ finalSolutionId: submissionId });
   }
 
-  handleOpenActivityMenu(event: any) {
-    this.setState({ activityMenu: { isOpen: true, anchorEl: event.currentTarget } });
-  }
-
-  handleCloseActivityMenu() {
-    this.setState({ activityMenu: { isOpen: false, anchorEl: null } });
-  }
-
   render() {
     const { classes, history } = this.props;
     const {
@@ -195,7 +167,6 @@ class SolveActivityPage extends React.Component<Props, State> {
       editor,
       pastSubmissionsPanel,
       finalSolutionId,
-      activityOptions
     } = this.state;
     return (
       <div>
@@ -229,7 +200,7 @@ class SolveActivityPage extends React.Component<Props, State> {
         )}
 
         {!activity && <CircularProgress className={classes.circularProgress} />}
-        {activity && activityOptions && (
+        {activity && (
           <div>
             <SolvePageHeader
               handleSubmitActivity={e => this.handleSubmitActivity(e)}
@@ -237,10 +208,6 @@ class SolveActivityPage extends React.Component<Props, State> {
               activity={activity}
               history={history}
               canShowOtherSolutions={finalSolutionId !== null}
-              handleOpenActivityMenu={e => this.handleOpenActivityMenu(e)}
-              handleCloseActivityMenu={() => this.handleCloseActivityMenu()}
-              activityMenu={this.state.activityMenu}
-              activityOptions={activityOptions}
             />
             <SplitPane
               split="vertical"

--- a/src/components/SolveActivityPage/SolveActivityPage.js
+++ b/src/components/SolveActivityPage/SolveActivityPage.js
@@ -52,6 +52,8 @@ type State = {
   editor: any,
   pastSubmissionsPanel: { isOpen: boolean, selectedSubmissionId: ?number },
   finalSolutionId: ?number,
+  activityMenu: { isOpen: boolean, anchorEl: ?string },
+  activityOptions: { options: Array<any> }
 };
 
 class SolveActivityPage extends React.Component<Props, State> {
@@ -65,6 +67,8 @@ class SolveActivityPage extends React.Component<Props, State> {
     editor: null,
     pastSubmissionsPanel: { isOpen: false, selectedSubmissionId: null },
     finalSolutionId: null,
+    activityMenu: { isOpen: false, anchorEl: null },
+    activityOptions: []
   };
 
   componentDidMount() {
@@ -86,6 +90,22 @@ class SolveActivityPage extends React.Component<Props, State> {
             }
             return Promise.reject(err);
           });
+        activitiesService
+          .getAllActivities(this.props.match.params.courseId)
+          .then(activitiesResponse => {
+            let activities = activitiesResponse
+              .filter(activity => (activity.category_id === activityResponse.category_id && activity.active))
+              .sort((a, b) => a.name > b.name);
+            this.setState({
+              activityOptions: activities.map(activity => ({id: activity.id, name: activity.name}))
+            })
+            .catch(err => {
+              if (err.status === 404) {
+                return Promise.resolve(this.setState({ activityOptions: [] }));
+              }
+              return Promise.reject(err);
+            });
+          })
       })
       .catch(err => {
         console.log(err);
@@ -155,6 +175,14 @@ class SolveActivityPage extends React.Component<Props, State> {
     this.setState({ finalSolutionId: submissionId });
   }
 
+  handleOpenActivityMenu(event: any) {
+    this.setState({ activityMenu: { isOpen: true, anchorEl: event.currentTarget } });
+  }
+
+  handleCloseActivityMenu() {
+    this.setState({ activityMenu: { isOpen: false, anchorEl: null } });
+  }
+
   render() {
     const { classes, history } = this.props;
     const {
@@ -167,6 +195,7 @@ class SolveActivityPage extends React.Component<Props, State> {
       editor,
       pastSubmissionsPanel,
       finalSolutionId,
+      activityOptions
     } = this.state;
     return (
       <div>
@@ -200,7 +229,7 @@ class SolveActivityPage extends React.Component<Props, State> {
         )}
 
         {!activity && <CircularProgress className={classes.circularProgress} />}
-        {activity && (
+        {activity && activityOptions && (
           <div>
             <SolvePageHeader
               handleSubmitActivity={e => this.handleSubmitActivity(e)}
@@ -208,6 +237,10 @@ class SolveActivityPage extends React.Component<Props, State> {
               activity={activity}
               history={history}
               canShowOtherSolutions={finalSolutionId !== null}
+              handleOpenActivityMenu={e => this.handleOpenActivityMenu(e)}
+              handleCloseActivityMenu={() => this.handleCloseActivityMenu()}
+              activityMenu={this.state.activityMenu}
+              activityOptions={activityOptions}
             />
             <SplitPane
               split="vertical"

--- a/src/components/SolveActivityPage/SolvePageHeader.react.js
+++ b/src/components/SolveActivityPage/SolvePageHeader.react.js
@@ -4,6 +4,10 @@ import React from "react";
 import Button from "@material-ui/core/Button";
 import { withStyles } from "@material-ui/core/styles";
 import { withState } from "../../utils/State";
+import IconButton from '@material-ui/core/IconButton';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
 
 import Breadcrumbs from "@material-ui/core/Breadcrumbs";
 import Link from "@material-ui/core/Link";
@@ -45,6 +49,10 @@ type Props = {
   history: any,
   canShowOtherSolutions: boolean,
   onlyTitle: boolean,
+  handleOpenActivityMenu: Event => void,
+  handleCloseActivityMenu: Event => void,
+  activityMenu: any,
+  activityOptions: Array<any>
 };
 
 function getLeftTitle(
@@ -78,7 +86,7 @@ function getLeftTitle(
 
 function SolvePageHeader(props: Props) {
   const { course } = props.context;
-  const { activity } = props;
+  const { activity, activityOptions, activityMenu } = props;
   return (
     <div style={props.style} className={props.classes.secondHeader}>
       <Breadcrumbs aria-label="breadcrumb">
@@ -90,6 +98,34 @@ function SolvePageHeader(props: Props) {
         </LinkRouter>
         <LinkRouter color="inherit" to={props.history.location.pathname}>
           {activity.name}
+          {activityOptions?.length > 0 && (
+            <IconButton
+              id="activity-menu"
+              aria-label="more"
+              aria-haspopup="true"
+              onClick={props.handleOpenActivityMenu}
+              style={{ padding: "6px" }}
+            >
+              <MoreVertIcon/>
+            </IconButton>
+          )}
+          <Menu
+            anchorEl={activityMenu.anchorEl}
+            open={activityMenu.isOpen}
+            onClose={props.handleCloseActivityMenu}
+            PaperProps={{ style: { maxHeight: 320 }}}
+          >
+            {activityOptions.map((option) => (
+              <MenuItem
+                selected={option.id === activity.id}
+                component={RouterLink}
+                to={`/courses/${course.id}/activities/${option.id}`}
+                key={option.id}
+              >
+                {option.name}
+              </MenuItem>
+            ))}
+          </Menu>
         </LinkRouter>
       </Breadcrumbs>
       {!props.onlyTitle && (

--- a/src/components/SolveActivityPage/SolvePageHeader.react.js
+++ b/src/components/SolveActivityPage/SolvePageHeader.react.js
@@ -133,16 +133,13 @@ class SolvePageHeader extends React.Component<Props, State> {
             Actividades
           </LinkRouter>
           <LinkRouter color="inherit" to={this.props.history.location.pathname}>
-            {activity.name}
-            <IconButton
-              id="activity-menu"
-              aria-label="more"
+            <Button
+              color="inherit"
               aria-haspopup="true"
               onClick={(e) => this.handleOpenActivityMenu(e)}
-              style={{ padding: "6px" }}
-            >
-              <MoreVertIcon/>
-            </IconButton>
+              variant='outlined'>
+              {activity.name}
+            </Button>
             <Menu
               anchorEl={activityMenu.anchorEl}
               open={activityMenu.isOpen}

--- a/src/components/SolveActivityPage/SolvePageHeader.react.js
+++ b/src/components/SolveActivityPage/SolvePageHeader.react.js
@@ -5,10 +5,9 @@ import Button from "@material-ui/core/Button";
 import { withStyles } from "@material-ui/core/styles";
 import { withState } from "../../utils/State";
 import activitiesService from "../../services/activitiesService";
-import IconButton from '@material-ui/core/IconButton';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
-import MoreVertIcon from '@material-ui/icons/MoreVert';
+import type { Activity } from "../../types";
 
 import Breadcrumbs from "@material-ui/core/Breadcrumbs";
 import Link from "@material-ui/core/Link";
@@ -54,7 +53,7 @@ type Props = {
 
 type State = {
   activityMenu: { isOpen: boolean, anchorEl: ?string },
-  activityOptions: Array<any>
+  activityOptions: Array<Activity>
 };
 
 function getLeftTitle(
@@ -96,11 +95,12 @@ class SolvePageHeader extends React.Component<Props, State> {
     activitiesService
       .getAllActivities(this.props.context.course.id)
       .then(activitiesResponse => {
+        // filter active activities and those which belong to the same category as the current one
         let activities = activitiesResponse
           .filter(activity => (activity.category_id === this.props.activity.category_id && activity.active))
           .sort((a, b) => a.name > b.name);
         this.setState({
-          activityOptions: activities.map(activity => ({id: activity.id, name: activity.name}))
+          activityOptions: activities
         })
       })
       .catch(err => {


### PR DESCRIPTION
Agrega un menú desplegable al nombre de la actividad para navegar a las otras actividades de la misma categoría.

https://user-images.githubusercontent.com/4763786/132620581-c4787c1f-7625-48fc-9f84-e6d4f0b36590.mp4

Como la API no tiene un endpoint para traer las actividades de una categoría determinada, se traen todas las actividades y se filtra por categoría.

(Seguro no hacía falta cambiar el `SolvePageHeader` de función a clase pero me resultó cómodo para hacer los cambios, puedo hacer el rollback, etc etc)