### PR TITLE
Remove CSS overflow: auto to topDiv on FinalActivities Page

### DIFF
--- a/src/components/FinalActivitiesPage/FinalActivitiesPage.js
+++ b/src/components/FinalActivitiesPage/FinalActivitiesPage.js
@@ -40,7 +40,7 @@ const styles = theme => ({
   },
   topDiv: {
     height: "100vh",
-    overflow: "auto",
+    // overflow: "auto",
   },
   splitPaneStyle: {
     height: "80vh",


### PR DESCRIPTION
Current
![image](https://user-images.githubusercontent.com/12226623/132746757-f7f7760a-2fc4-499d-b157-e8cdae21538c.png)

Without overflow
![image](https://user-images.githubusercontent.com/12226623/132746836-a7e024da-367b-4ec3-8d97-870d2d5ff8c0.png)
