### PR TITLE
Submission result modal: open stdout and stderr automatically on error

### DIFF
--- a/src/components/SubmissionResultModal/StdAccordion.js
+++ b/src/components/SubmissionResultModal/StdAccordion.js
@@ -13,9 +13,9 @@ type Props = {
 };
 
 const StdAccordion = (props: Props) => {
-  const { title, std = "", getColor } = props;
+  const { title, std = "", getColor, startExpanded = false } = props;
 
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(startExpanded);
 
   const handleExpanded = (event: Event, isExpanded: boolean) => {
     setExpanded(isExpanded);

--- a/src/components/SubmissionResultModal/TestResultsModal.react.js
+++ b/src/components/SubmissionResultModal/TestResultsModal.react.js
@@ -192,6 +192,9 @@ class SubmissionResultModal extends React.Component<Props, State> {
       return "textSecondary";
     };
 
+    const expandStd = results
+      && (results.submission_status === "BUILD_ERROR" || results.submission_status === "RUNTIME_ERROR")
+
     const getStdoutColor = (item: string) => {
       if (item.includes("start_BUILD") || item.includes("end_BUILD")) {
         return "secondary";
@@ -201,7 +204,6 @@ class SubmissionResultModal extends React.Component<Props, State> {
       }
       return "textSecondary";
     };
-
     return (
       <div>
         {error.open && <ErrorNotification open={error.open} message={error.message} />}
@@ -280,13 +282,21 @@ class SubmissionResultModal extends React.Component<Props, State> {
               {/* Stderr */}
               {results.stderr && (
                 <Box mb={3}>
-                  <StdAccordion title="Stderr" std={results.stderr} getColor={getStderrColor} />
+                  <StdAccordion
+                    title="Stderr"
+                    std={results.stderr}
+                    getColor={getStderrColor}
+                    startExpanded={expandStd} />
                 </Box>
               )}
               {/* Stdout */}
               {results.stdout && (
                 <Box mb={3}>
-                  <StdAccordion title="Stdout" std={results.stdout} getColor={getStdoutColor} />
+                  <StdAccordion
+                    title="Stdout"
+                    std={results.stdout}
+                    getColor={getStdoutColor}
+                    startExpanded={expandStd} />
                 </Box>
               )}
               <DialogActions>


### PR DESCRIPTION
Entregas que no compilan o tienen error de ejecución no muestran las pruebas. La información relevante del modal está bajo `stderr` y `stdout` que por defecto están cerrados, y no queda claro para el usuario.

El PR cambia esto para que estas secciones estén abiertas por defecto si el resultado de la entrega fue un error de compilación o de ejecución.

Antes: 
![image](https://user-images.githubusercontent.com/4763786/138734811-31a2d654-bc5d-4cb0-87d1-4cd9caf19271.png)


Después:
![image](https://user-images.githubusercontent.com/4763786/138734843-7aa0c93b-7fdd-40dc-8f63-7bdf16cbb258.png)