### PR TITLE
Enable HTTPS

### DIFF
--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -26,7 +26,7 @@ env:
   IMAGE: rpl-web
   REGISTRY_HOSTNAME: gcr.io
   DEPLOYMENT_NAME: webapp
-  API_BASE_URL: http://myrpl.ar
+  API_BASE_URL: https://myrpl.ar
   CLOUDINARY_UPLOAD_PRESET: ${{ secrets.CLOUDINARY_UPLOAD_PRESET }}
   CLOUDINARY_URL: https://api.cloudinary.com/v1_1/tutecano22/image/upload
 

--- a/kubernetes/ingress/managed-cert-ingress.yaml
+++ b/kubernetes/ingress/managed-cert-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: managed-cert-ingress
+  annotations:
+    # kubernetes.io/ingress.regional-static-ip-name: rpl2-ssl-ingress
+    networking.gke.io/managed-certificates: managed-cert
+    kubernetes.io/ingress.class: "gce"
+spec:
+  defaultBackend:
+    service:
+      name: webapp
+      port:
+        number: 80

--- a/kubernetes/ingress/managed-cert-ingress.yaml
+++ b/kubernetes/ingress/managed-cert-ingress.yaml
@@ -1,10 +1,12 @@
 apiVersion: networking.k8s.io/v1
-kind: Ingress
+kind: Ingress  # Basicamente crea un Cloud Load Balancer en GCE y lo apunta al nginx
 metadata:
   name: managed-cert-ingress
   annotations:
+    # Por alguna razon no pude configurar una static IP existente, de todos modos al deployar esto se crea una. OJO que si se deploya multiples veces se van a crear constantemente nuevas IPs
     # kubernetes.io/ingress.regional-static-ip-name: rpl2-ssl-ingress
     networking.gke.io/managed-certificates: managed-cert
+    # Notar que el encriptado SSL (HTTPS) va hasta el LoadBalancer manejado por google. Osea que el trafico que le llega al nginx ya es HTTP
     kubernetes.io/ingress.class: "gce"
 spec:
   defaultBackend:

--- a/kubernetes/ingress/managed-cert.yaml
+++ b/kubernetes/ingress/managed-cert.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: managed-cert
+spec:
+  domains:
+    - myrpl.ar
+    - www.myrpl.ar

--- a/kubernetes/services/web.yaml
+++ b/kubernetes/services/web.yaml
@@ -10,4 +10,4 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 80
-  type: LoadBalancer                # Exposes the service by opening a port on each node
+  type: NodePort      # Exposes the service by opening a port on each node


### PR DESCRIPTION
Changed kubernetes configuration 

from
- a webapp service of type LoadBalancer

to
- ManagedCertificate object for domains myrpl.ar and www.myrpl.ar
- Ingress associated to the ManagedCertificate, pointing to the webapp service